### PR TITLE
Change the concurrency in vanilla.py

### DIFF
--- a/src/hirag_mcp/_utils.py
+++ b/src/hirag_mcp/_utils.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
 from hashlib import md5
-from typing import Any
+from typing import Any, Coroutine, Iterable, List, TypeVar
 
 import numpy as np
 import tiktoken
@@ -322,3 +322,19 @@ async def _handle_single_relationship_extraction(
         description=edge_description,
         source_id=chunk_key,
     )
+
+
+T = TypeVar("T")
+
+
+async def _limited_gather(
+    coros: Iterable[Coroutine[Any, Any, T]], limit: int
+) -> List[T]:
+    sem = asyncio.Semaphore(limit)
+
+    async def _worker(c):
+        async with sem:
+            return await c
+
+    tasks = [asyncio.create_task(_worker(c)) for c in coros]
+    return await asyncio.gather(*tasks)

--- a/src/hirag_mcp/entity/vanilla.py
+++ b/src/hirag_mcp/entity/vanilla.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List
 from hirag_mcp._utils import (
     _handle_single_entity_extraction,
     _handle_single_relationship_extraction,
+    _limited_gather,
     compute_mdhash_id,
     pack_user_ass_to_openai_messages,
     split_string_by_multi_markers,
@@ -200,12 +201,18 @@ class VanillaEntity(BaseEntity):
             )
             return entity
 
+        entity_extraction_concurrency: int = 4
+        entity_merge_concurrency: int = 2
+
+        extraction_coros = [_process_single_content_entity(chunk) for chunk in chunks]
+
         # entities_list is a list of list of entities
         # because _process_single_content_entity returns a list of entities
         # TODO: handle the concurrent entity extraction
-        entities_list = await asyncio.gather(
-            *[_process_single_content_entity(chunk) for chunk in chunks]
+        entities_list = await _limited_gather(
+            extraction_coros, entity_extraction_concurrency
         )
+
         # Flatten the list of entity lists into a single list of entities
         entities = [entity for entity_list in entities_list for entity in entity_list]
         # merge entities with the same id
@@ -222,12 +229,13 @@ class VanillaEntity(BaseEntity):
         entities_to_merge_by_name = defaultdict(list)
         for entity in entities_to_merge:
             entities_to_merge_by_name[entity.page_content].append(entity)
-        merged_entities = await asyncio.gather(
-            *[
-                _merge_entities(entity_name, entities)
-                for entity_name, entities in entities_to_merge_by_name.items()
-            ]
-        )
+
+        merge_coros = [
+            _merge_entities(name, ents)
+            for name, ents in entities_to_merge_by_name.items()
+        ]
+        merged_entities = await _limited_gather(merge_coros, entity_merge_concurrency)
+
         return entities_unique + merged_entities
 
     async def relation(

--- a/src/hirag_mcp/entity/vanilla.py
+++ b/src/hirag_mcp/entity/vanilla.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 import warnings
 from collections import Counter, defaultdict
@@ -338,22 +337,28 @@ class VanillaEntity(BaseEntity):
                     relations.append(relation)
             return relations
 
-        relations_list = await asyncio.gather(
-            *[
-                _process_single_content_relation(
-                    chunk,
-                    {
-                        e.page_content: e
-                        for e in entities
-                        if chunk.id in e.metadata.chunk_ids
-                    },
-                )
-                for chunk in chunks
-            ]
+        relation_extraction_concurrency: int = 5
+
+        relation_coros = [
+            _process_single_content_relation(
+                chunk,
+                {
+                    e.page_content: e
+                    for e in entities
+                    if chunk.id in e.metadata.chunk_ids
+                },
+            )
+            for chunk in chunks
+        ]
+
+        relations_list = await _limited_gather(
+            relation_coros, relation_extraction_concurrency
         )
+
         relations = [
             relation for relation_list in relations_list for relation in relation_list
         ]
+
         # We do not merge relations here, because relations represents facts/relationships between entities
         # and it is supposed to have multiple relations between the same entities
         return relations

--- a/src/hirag_mcp/hirag.py
+++ b/src/hirag_mcp/hirag.py
@@ -5,9 +5,10 @@ import os
 import time
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
-from typing import Coroutine, Optional
+from typing import Optional
 
 from hirag_mcp._llm import gpt_4o_mini_complete, openai_embedding
+from hirag_mcp._utils import _limited_gather
 from hirag_mcp.chunk import BaseChunk, FixTokenChunk
 from hirag_mcp.entity import BaseEntity, VanillaEntity
 from hirag_mcp.loader import load_document
@@ -76,18 +77,6 @@ class HiRAG:
             )
         return cls._chunk_pool
 
-    async def _limited_gather(self, coros: list[Coroutine], max_concurrency: int):
-        """
-        Concurrently schedule coroutines in the coros list, with at most max_concurrency running simultaneously.
-        """
-        sem = asyncio.Semaphore(max_concurrency)
-
-        async def _worker(coro):
-            async with sem:
-                return await coro
-
-        return await asyncio.gather(*[_worker(coro) for coro in coros])
-
     chunk_upsert_concurrency: int = 4
     entity_upsert_concurrency: int = 4
     relation_upsert_concurrency: int = 2
@@ -110,7 +99,7 @@ class HiRAG:
             )
             for chunk in chunks
         ]
-        await self._limited_gather(chunk_coros, self.chunk_upsert_concurrency)
+        await _limited_gather(chunk_coros, self.chunk_upsert_concurrency)
 
         entities = await self.entity_extractor.entity(chunks)
         entity_coros = [
@@ -126,11 +115,11 @@ class HiRAG:
             )
             for ent in entities
         ]
-        await self._limited_gather(entity_coros, self.entity_upsert_concurrency)
+        await _limited_gather(entity_coros, self.entity_upsert_concurrency)
 
         relations = await self.entity_extractor.relation(chunks, entities)
         relation_coros = [self.gdb.upsert_relation(rel) for rel in relations]
-        await self._limited_gather(relation_coros, self.relation_upsert_concurrency)
+        await _limited_gather(relation_coros, self.relation_upsert_concurrency)
 
     async def insert_to_kb(
         self,


### PR DESCRIPTION
Limit the concurrency of the extraction and merge phases within the entity method.
Limit the concurrency of the extraction within the relation process.